### PR TITLE
add repository to Cargo.toml

### DIFF
--- a/crates/dlq-cli/Cargo.toml
+++ b/crates/dlq-cli/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "a CLI tool for polling the messages from your AWS DLQ instance"
+repository = "https://github.com/isaacadams/dlq"
 
 [[bin]]
 name = "dlq"

--- a/crates/dlq-core/Cargo.toml
+++ b/crates/dlq-core/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "easily poll messages from your AWS DLQ instance"
+repository = "https://github.com/isaacadams/dlq"
 
 [lib]
 name = "dlq"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.